### PR TITLE
add: enable to delete space in card number field

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ export default function App() {
     watch,
     register,
     reset,
+    setValue,
     control,
     formState: { errors },
     handleSubmit,
@@ -33,7 +34,7 @@ export default function App() {
         srcSet={`${bgMainMobile} 375w, ${bgMainDesktop} 483w`}
       />
       <Card cardData={watch()} />
-      <Form {...{ handleSubmit, control, errors, register, reset }} />
+      <Form {...{ handleSubmit, control, errors, register, reset, setValue }} />
     </main>
   );
 }

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,7 +1,7 @@
 import { useController } from "react-hook-form";
 import { formatCardNumber } from "./utils/formatter";
 import style from "./styles/Form.module.css";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import iconComplete from "./assets/images/icon-complete.svg";
 
 export default function Form({
@@ -9,6 +9,7 @@ export default function Form({
   control,
   errors,
   register,
+  setValue,
   reset,
 }) {
   const {
@@ -43,6 +44,18 @@ export default function Form({
     reset();
   }
 
+  const handleCardNumberBackspace = useCallback((e) => {
+    const deleteIfLastLetterIsSpace = () => {
+      const cardNumber = e.target.value || '';
+      const lastLetter = cardNumber[cardNumber.length - 1];
+      if (lastLetter !== ' ') return;
+  
+      setValue('number', cardNumber.substring(0, cardNumber.length - 1));
+    };
+
+    if (e.key !== 'Backspace') return; deleteIfLastLetterIsSpace();
+  }, [setValue]);
+
   if (isComplete)
     return (
       <div className={style.complete}>
@@ -73,6 +86,7 @@ export default function Form({
           cardNumberField.onChange(formatCardNumber(e.target.value));
         }}
         onBlur={cardNumberField.onBlur}
+        onKeyDown={handleCardNumberBackspace}
         value={cardNumberField.value}
         ref={cardNumberField.ref}
         inputMode="numeric"


### PR DESCRIPTION
Problem: Space wasn't able to be removed by pressing backspace in the card number input field since the regular expression adds an extra space at the end of the input value.

```javascript
export function formatCardNumber(numberStr) {
  return numberStr
    .replace(/\W/gi, "")
    .replace(/(.{4})/g, "$1 ") // Here
    .substring(0, 19);
}

```

Solution: Add a key-down handler to the input field to detect the text change before firing `onChange`. In the handler, it removes a spacebar when pressing the backspace. 

---

Things that should be considered.

- It uses `react-hook-form` but in the event handler, it accesses the value through the event argument.
- Naming
- When the card number is changed, the cursor moves at the end of the input. In my opinion, it would be not harmful to UX, I mean I think it might be better. The card number is really important data, and allowing users to change in the middle of the text may cause typos the way I see it.